### PR TITLE
Added missing GPIO mappings for the NanoPi NEO (GPIOC0, GPIOC1, GPIOC3)

### DIFF
--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -11,8 +11,8 @@ int initPinGPIO(int board)
     switch(board) {
     case BOARD_NANOPI_M1: {
         int tempPinGPIO[41] = {-1, -1, -1, -1, -1, -1,  -1, 203, 198, -1, 199,
-                                    0,  6,  2, -1,  3, 200,  -1, 201, -1, -1,
-                                   -1,  1, -1, -1, -1,  -1,  -1,  -1, 20, -1,
+                                    0,  6,  2, -1,  3, 200,  -1, 201, 64, -1,
+                                   65,  1, -1, 67, -1,  -1,  -1,  -1, 20, -1,
                                    21,  7,  8, -1, 16,  13,   9,  15, -1, 14,
                                   };
         memcpy(pinGPIO, tempPinGPIO, sizeof(pinGPIO));


### PR DESCRIPTION
The mappings for GPIOC0, GPIOC1 all GPIOC3 returned -1.  
Updated this to return the correct values.  

Note that GPIOC2, for some reason, cannot be used even if the correct mapping  
is added, that is why it's not included here.

Did not test this on a NanoPI M1 since I don't have one at this time.  
I'm assuming the result will be the same since both the Neo and M1 return the same BoardId.

