### PR TITLE
fix: oled demo can't work well. tested on NanoPi Neo Air

### DIFF
--- a/lib/oled.c
+++ b/lib/oled.c
@@ -256,9 +256,8 @@ EXPORT int OLEDInit(int cmdDatPin, int resetPin)
         ret = -1;
     }
 */
-    if (OLEDSetPos(devFD, 0, 0) == -1) {
-        ret = -1;
-    }
+    ret = OLEDSetPos(devFD, 0, 0);
+    
     if (ret == 0) {
         return devFD;
     } else {


### PR DESCRIPTION
在测试的时候发现oled的demo在NanoPi Neo Air 上工作不正常。改过之后在NanoPi Neo Air上测试正常。